### PR TITLE
Add limit for pipelines

### DIFF
--- a/.github/workflows/account.yml
+++ b/.github/workflows/account.yml
@@ -16,6 +16,7 @@ jobs:
         java: [11]
     
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/feedback.yml
+++ b/.github/workflows/feedback.yml
@@ -16,6 +16,7 @@ jobs:
         java: [11]
     
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/portfolio.yml
+++ b/.github/workflows/portfolio.yml
@@ -16,6 +16,7 @@ jobs:
         java: [11]
 
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/stock-quote.yml
+++ b/.github/workflows/stock-quote.yml
@@ -16,6 +16,7 @@ jobs:
         java: [11]
 
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
**What has been done?**

- add time limit for all pipelines

**Why do you changed it?**

- a [pipeline](https://github.com/whzinformatik/stocktrader/actions/runs/432444760) ran for over four hours

**Instructions for testing**

- check if all pipelines are green

**Checks**
- [x] I reviewed my own code
- [ ] I have documented my code
- [ ] I have tested my code
- [ ] I have linked the issue to the pull request
